### PR TITLE
Biscuit does not export yaml, so don't yaml-parse it

### DIFF
--- a/lib/biscuit/secrets_decrypter.rb
+++ b/lib/biscuit/secrets_decrypter.rb
@@ -26,9 +26,16 @@ module Biscuit
       @_exported ||= Biscuit.run!("export -f '#{secrets_file}'")
     end
 
+    def secret_lines
+      @_secret_lines ||= exported.split("\n").select { |line| line =~ /\S/ }
+    end
+
+    def secret_pairs
+      @_secret_pairs ||= secret_lines.map { |line| line.split(":").map(&:strip) }
+    end
+
     def secrets
-      return @_secrets if defined?(@_secrets)
-      @_secrets = YAML.load(exported)
+      @_secrets ||= Hash[secret_pairs]
     end
   end
 end

--- a/lib/biscuit/secrets_decrypter.rb
+++ b/lib/biscuit/secrets_decrypter.rb
@@ -22,11 +22,13 @@ module Biscuit
 
     private
 
-    def secrets
-      return @secrets if defined? @secrets
+    def exported
+      @_exported ||= Biscuit.run!("export -f '#{secrets_file}'")
+    end
 
-      result   = Biscuit.run!("export -f #{secrets_file}")
-      @secrets = YAML.load(result)
+    def secrets
+      return @_secrets if defined?(@_secrets)
+      @_secrets = YAML.load(exported)
     end
   end
 end

--- a/lib/biscuit/version.rb
+++ b/lib/biscuit/version.rb
@@ -1,3 +1,3 @@
 module Biscuit
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/lib/secrets_decrypter_spec.rb
+++ b/spec/lib/secrets_decrypter_spec.rb
@@ -22,10 +22,11 @@ describe Biscuit::SecretsDecrypter do
   describe ".load" do
     shared_examples "translates exported data correctly" do
       let(:decrypter) { described_class.new(secret_file) }
+      before { allow(File).to receive(:exists?).and_return(true) }
       before { allow(Biscuit).to receive(:run!).and_return(exported_data) }
 
       it "executes the correct biscuit command" do
-        expect(Biscuit).to receive(:run!).with("export -f '/tmp/secrets.yml'")
+        expect(Biscuit).to receive(:run!).with("export -f '#{secret_file}'")
         decrypter.load
       end
 

--- a/spec/lib/secrets_decrypter_spec.rb
+++ b/spec/lib/secrets_decrypter_spec.rb
@@ -52,5 +52,25 @@ describe Biscuit::SecretsDecrypter do
       let(:expected_hash) { Hash["secret_key" => "secret_value"] }
       include_examples "translates exported data correctly"
     end
+
+    context "for many key-value pairs" do
+      let(:exported_data) do
+        <<~EXPORTED
+          foo: bar
+          bam: baz
+          one: two
+        EXPORTED
+      end
+
+      let(:expected_hash) do
+        {
+          "foo" => "bar",
+          "bam" => "baz",
+          "one" => "two",
+        }
+      end
+
+      include_examples "translates exported data correctly"
+    end
   end
 end

--- a/spec/lib/secrets_decrypter_spec.rb
+++ b/spec/lib/secrets_decrypter_spec.rb
@@ -72,5 +72,17 @@ describe Biscuit::SecretsDecrypter do
 
       include_examples "translates exported data correctly"
     end
+
+    context "when the keys and values look numeric" do
+      let(:exported_data) { "58: 49" }
+      let(:expected_hash) { Hash["58" => "49"] }
+      include_examples "translates exported data correctly"
+    end
+
+    context "when the values look like arrays" do
+      let(:exported_data) { "foo: 1,2,3,4,5" }
+      let(:expected_hash) { Hash["foo" => "1,2,3,4,5"] }
+      include_examples "translates exported data correctly"
+    end
   end
 end

--- a/spec/lib/secrets_decrypter_spec.rb
+++ b/spec/lib/secrets_decrypter_spec.rb
@@ -25,7 +25,7 @@ describe Biscuit::SecretsDecrypter do
       before { allow(Biscuit).to receive(:run!).and_return(exported_data) }
 
       it "executes the correct biscuit command" do
-        expect(Biscuit).to receive(:run!).with("export -f /tmp/secrets.yml")
+        expect(Biscuit).to receive(:run!).with("export -f '/tmp/secrets.yml'")
         decrypter.load
       end
 


### PR DESCRIPTION
# Motivation

I discovered in an Uploader PR (to move stuff from CF to biscuit) that `LEGACY_INITIALIZATION_VECTOR` had some kind of problem after I moved it. Investigation showed that, when I `biscuit put -f FILE LEGACY_INITIALIZATION_VECTOR 1,2,3,4,5`, the actual envar being supplied back by biscuit in staging was `"12345"`.

When I dug into the details, this turned out to be because `biscuit export` is printing out its data in a raw `KEY: VALUE` format, which is not actually YAML, but resembles it strongly. We YAML-parse the output of that file, which results in getting an Array value for that key, and then cast it to a string in the library.

While my initial reaction was to just switch to using some other separator that YAML doesn't care about, I think this is a gotcha that will catch others, especially since biscuit doesn't actually get used locally.

# Changes
* Refactored the SecretsDecrypter specs around a set of shared examples
* Added a few examples, including two that fail (numeric keys/values, and array value)
* Rewrite the SecretsDecrypter to avoid using `YAML.load` (use raw string-splitting instead)
* Quote the path to the secrets file in the bash command - this would only cause issues to someone that has oddities in the full-path to their source directories, but it could happen!
* Bump the version to 0.1.1 - this is sufficiently backwards-compatible in my book. If anyone is relying on *this* behavior, they're being foolish.