### PR TITLE
Revert to yaml style loading..

### DIFF
--- a/lib/biscuit/secrets_decrypter.rb
+++ b/lib/biscuit/secrets_decrypter.rb
@@ -22,20 +22,12 @@ module Biscuit
 
     private
 
+    def secrets
+      @_secrets ||= YAML.load(exported)
+    end
+
     def exported
       @_exported ||= Biscuit.run!("export -f '#{secrets_file}'")
-    end
-
-    def secret_lines
-      @_secret_lines ||= exported.split("\n").select { |line| line =~ /\S/ }
-    end
-
-    def secret_pairs
-      @_secret_pairs ||= secret_lines.map { |line| line.split(":").map(&:strip) }
-    end
-
-    def secrets
-      @_secrets ||= Hash[secret_pairs]
     end
   end
 end

--- a/spec/lib/secrets_decrypter_spec.rb
+++ b/spec/lib/secrets_decrypter_spec.rb
@@ -74,14 +74,14 @@ describe Biscuit::SecretsDecrypter do
       include_examples "translates exported data correctly"
     end
 
-    context "when the keys and values look numeric" do
-      let(:exported_data) { "58: 49" }
+    context "when the keys and values look numeric and are quoted" do
+      let(:exported_data) { "'58': '49'" }
       let(:expected_hash) { Hash["58" => "49"] }
       include_examples "translates exported data correctly"
     end
 
-    context "when the values look like arrays" do
-      let(:exported_data) { "foo: 1,2,3,4,5" }
+    context "when the values look like arrays and are quoted" do
+      let(:exported_data) { "foo: '1,2,3,4,5'" }
       let(:expected_hash) { Hash["foo" => "1,2,3,4,5"] }
       include_examples "translates exported data correctly"
     end

--- a/spec/lib/secrets_decrypter_spec.rb
+++ b/spec/lib/secrets_decrypter_spec.rb
@@ -85,5 +85,25 @@ describe Biscuit::SecretsDecrypter do
       let(:expected_hash) { Hash["foo" => "1,2,3,4,5"] }
       include_examples "translates exported data correctly"
     end
+
+    context "when the values have a :" do
+      let(:exported_data) { "foo: http://bar.com" }
+      let(:expected_hash) { Hash["foo" => "http://bar.com"] }
+      include_examples "translates exported data correctly"
+    end
+
+    context "for multiline strings" do
+      let(:exported_data) do
+        <<~EXPORTED
+          foo: |
+            bar
+            biz
+        EXPORTED
+      end
+
+      let(:expected_hash) { Hash["foo" => "bar\nbiz\n"] }
+
+      include_examples "translates exported data correctly"
+    end
   end
 end


### PR DESCRIPTION
Revert loading back to the use-YAML way..
- Otherwise multiline values break like crazy
- Update specs that would fail otherwise, to show that you must quote
numbers containing commas
  - See ruby/psych#273 for why..