### PR TITLE
Fixing deprecated open() call

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+# 0.1.4
+- [FIX] `open()` is deprecated for URIs. Uses `URI.open()`
+- Bumps bundler version
+- Bumps rake gem version
+
 # 0.1.3
 - No changes - apparently there was already a yanked 0.1.2 out there somewhere
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ end
 def download_file(url)
   filename = URI(url).path.split('/').last
 
-  IO.copy_stream(open(url), "/tmp/#{filename}")
+  IO.copy_stream(URI.open(url), "/tmp/#{filename}")
 
   "/tmp/#{filename}"
 end

--- a/biscuit.gemspec
+++ b/biscuit.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions    = ["Rakefile"]
 
-  spec.add_development_dependency "bundler", "~> 1.9"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.1"
+  spec.add_development_dependency "rake", "~> 13.0"
 
   spec.add_runtime_dependency "rake"
 end

--- a/lib/biscuit/version.rb
+++ b/lib/biscuit/version.rb
@@ -1,3 +1,3 @@
 module Biscuit
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
Replaces the `open()` call with `URI.open()` since `open()` doesn't work with URIs in the latest version of Ruby.

Bumps the version of the rake gem to remove some deprecation warnings.

Bumps the bundler version.

Increments this gem's version number to 0.1.4.