### PR TITLE
bump upstream version to 0.1.4

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+# 0.2.0
+- [FIX] Resolve File.exists? deprecation removal in latest Ruby.
+- Bump upstream biscuit binary dependency to latest 0.1.4 release.
+- Adds diagnostic logging to install task.
+
 # 0.1.4
 - [FIX] `open()` is deprecated for URIs. Uses `URI.open()`
 - Bumps bundler version

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,7 @@ def fetch(release_url)
 
   system("tar -xzf #{tgz_path} -C #{File.dirname(tgz_path)}") || raise
   system("mv #{File.dirname(tgz_path)}/biscuit #{__dir__}/bin/_biscuit") || raise
+  puts "Successfully fetched native biscuit executable"
 end
 
 def download_file(url)
@@ -25,7 +26,7 @@ task :default do
     "https://github.com/dcoker/biscuit/releases/download/v#{UPSTREAM_VERSION}/biscuit_#{UPSTREAM_VERSION}_"
 
   if platform.os == 'darwin'
-    fetch("#{base_release_url}MacOS-all.tgz")
+    fetch("#{base_release_url}MacOS-all.tar.gz")
   elsif platform.os == 'linux' && platform.cpu == 'x86_64'
     fetch("#{base_release_url}Linux-64bit.tar.gz")
   else

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require 'bundler/gem_tasks'
 UPSTREAM_VERSION = '0.1.4'
 
 def fetch(release_url)
+  puts "Fetching native biscuit executable: #{release_url}"
   tgz_path = download_file(release_url)
 
   system("tar -xzf #{tgz_path} -C #{File.dirname(tgz_path)}") || raise

--- a/Rakefile
+++ b/Rakefile
@@ -21,12 +21,13 @@ end
 
 task :default do
   platform = Gem::Platform.local
-  base_release_url = "https://github.com/dcoker/biscuit/releases/download/v#{UPSTREAM_VERSION}/biscuit"
+  base_release_url = 
+    "https://github.com/dcoker/biscuit/releases/download/v#{UPSTREAM_VERSION}/biscuit_#{UPSTREAM_VERSION}_"
 
-  if platform.os == 'darwin' && platform.cpu == 'x86_64'
-    fetch("#{base_release_url}-darwin_amd64.tgz")
+  if platform.os == 'darwin'
+    fetch("#{base_release_url}MacOS-all.tgz")
   elsif platform.os == 'linux' && platform.cpu == 'x86_64'
-    fetch("#{base_release_url}-linux_amd64.tgz")
+    fetch("#{base_release_url}Linux-64bit.tar.gz")
   else
     puts "Unsupported platform #{platform}"
   end

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'open-uri'
 require 'bundler/gem_tasks'
 
-UPSTREAM_VERSION = '0.1.3'
+UPSTREAM_VERSION = '0.1.4'
 
 def fetch(release_url)
   tgz_path = download_file(release_url)

--- a/lib/biscuit/secrets_decrypter.rb
+++ b/lib/biscuit/secrets_decrypter.rb
@@ -5,7 +5,7 @@ module Biscuit
     attr_reader :secrets_file
 
     def initialize(secrets_file)
-      fail "#{secrets_file} is not found" unless File.exists? secrets_file
+      fail "#{secrets_file} is not found" unless File.exist? secrets_file
 
       @secrets_file = secrets_file
     end

--- a/lib/biscuit/version.rb
+++ b/lib/biscuit/version.rb
@@ -1,3 +1,3 @@
 module Biscuit
-  VERSION = "0.1.4"
+  VERSION = "0.2.0"
 end

--- a/spec/lib/secrets_decrypter_spec.rb
+++ b/spec/lib/secrets_decrypter_spec.rb
@@ -9,12 +9,12 @@ describe Biscuit::SecretsDecrypter do
     subject(:decrypter) { -> { described_class.new(secret_file) } }
 
     context "when the file exists" do
-      before { allow(File).to receive(:exists?).and_return(true) }
+      before { allow(File).to receive(:exist?).and_return(true) }
       it { is_expected.not_to raise_error }
     end
 
     context "when the file doesn't exist" do
-      before { allow(File).to receive(:exists?).and_return(false) }
+      before { allow(File).to receive(:exist?).and_return(false) }
       it { is_expected.to raise_error(StandardError, /is not found/) }
     end
   end
@@ -22,7 +22,7 @@ describe Biscuit::SecretsDecrypter do
   describe ".load" do
     shared_examples "translates exported data correctly" do
       let(:decrypter) { described_class.new(secret_file) }
-      before { allow(File).to receive(:exists?).and_return(true) }
+      before { allow(File).to receive(:exist?).and_return(true) }
       before { allow(Biscuit).to receive(:run!).and_return(exported_data) }
 
       it "executes the correct biscuit command" do


### PR DESCRIPTION
Trying to run biscuit on MacOS monterry, you get the following error:

```
fatal error: runtime: bsdthread_register error

runtime stack:
runtime.throw(0x5060e9, 0x21)
	/usr/local/go/src/runtime/panic.go:566 +0x95 fp=0x7ff7bfeff320 sp=0x7ff7bfeff300
runtime.goenvs()
	/usr/local/go/src/runtime/os_darwin.go:88 +0xa0 fp=0x7ff7bfeff350 sp=0x7ff7bfeff320
runtime.schedinit()
	/usr/local/go/src/runtime/proc.go:450 +0x9c fp=0x7ff7bfeff390 sp=0x7ff7bfeff350
runtime.rt0_go(0x7ff7bfeff3c8, 0x1, 0x7ff7bfeff3c8, 0x0, 0x1000, 0x1, 0x7ff7bfeff600, 0x0, 0x7ff7bfeff658, 0x7ff7bfeff66c, ...)
	/usr/local/go/src/runtime/asm_amd64.s:145 +0x14f fp=0x7ff7bfeff398 sp=0x7ff7bfeff390
```

@JonathanWThom in an internal discussion board proved that compiling from the latest source for https://github.com/dcoker/biscuit and replacing the version of the `_biscuit` executable included with the gem would resolve the issue.

My theory is that the latest published release of biscuit should also resolve the error, without manual intervention on the part of someone installing the gem.

## Test Results

Latest 0.1.4 release will resolve the error

<img width="921" alt="image" src="https://user-images.githubusercontent.com/3124548/168136592-39531390-358a-4b90-99eb-8abafe7257ea.png">

tested on

<img width="579" alt="image" src="https://user-images.githubusercontent.com/3124548/168136881-720cf13d-05b5-4a55-b4cf-ac5fa868423f.png">

